### PR TITLE
Add OpenAPI/Swagger documentation with springdoc-openapi v3.0.1

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -36,6 +36,7 @@ dependencies {
     implementation("org.springframework.ai:spring-ai-starter-model-openai")
     implementation("tools.jackson.module:jackson-module-kotlin")
     implementation("org.springframework.boot:spring-boot-starter-actuator")
+    implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:3.0.1")
     implementation("org.kohsuke:github-api:2.0-rc.5")
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
     // Source: https://mvnrepository.com/artifact/io.jsonwebtoken/jjwt-api

--- a/src/main/kotlin/com/example/serviceportfolio/config/OpenApiConfig.kt
+++ b/src/main/kotlin/com/example/serviceportfolio/config/OpenApiConfig.kt
@@ -1,0 +1,38 @@
+package com.example.serviceportfolio.config
+
+import io.swagger.v3.oas.models.OpenAPI
+import io.swagger.v3.oas.models.info.Contact
+import io.swagger.v3.oas.models.info.Info
+import io.swagger.v3.oas.models.info.License
+import io.swagger.v3.oas.models.servers.Server
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class OpenApiConfig {
+
+    @Bean
+    fun openApi(): OpenAPI = OpenAPI()
+        .info(
+            Info()
+                .title("Service Portfolio API")
+                .description("REST API that analyzes GitHub repositories and generates professional developer portfolios using AI")
+                .version("1.0.0")
+                .contact(
+                    Contact()
+                        .name("Pablo Hurtado Gonzalo")
+                        .url("https://github.com/PabloHurtadoGonzalo86")
+                )
+                .license(
+                    License()
+                        .name("MIT")
+                        .url("https://opensource.org/licenses/MIT")
+                )
+        )
+        .servers(
+            listOf(
+                Server().url("https://serviceportfolioapi.pablohgdev.com").description("Production"),
+                Server().url("http://localhost:8080").description("Local development")
+            )
+        )
+}

--- a/src/main/kotlin/com/example/serviceportfolio/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/example/serviceportfolio/config/SecurityConfig.kt
@@ -41,6 +41,7 @@ class SecurityConfig(
                     .requestMatchers("/api/v1/repos/analyses/{id}").permitAll()
                     .requestMatchers("/api/v1/portfolio/**").permitAll()
                     .requestMatchers("/actuator/health").permitAll()
+                    .requestMatchers("/swagger-ui/**", "/swagger-ui.html", "/api-docs/**", "/api-docs.yaml").permitAll()
                     .requestMatchers("/").permitAll()
                     .anyRequest().authenticated()
             }

--- a/src/main/kotlin/com/example/serviceportfolio/controller/PortfolioController.kt
+++ b/src/main/kotlin/com/example/serviceportfolio/controller/PortfolioController.kt
@@ -4,6 +4,9 @@ import com.example.serviceportfolio.dtos.GeneratePortfolioRequest
 import com.example.serviceportfolio.dtos.PortfolioResponse
 import com.example.serviceportfolio.dtos.PortfolioSummaryResponse
 import com.example.serviceportfolio.services.PortfolioGenerationService
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.validation.Valid
 import org.slf4j.LoggerFactory
 import org.springframework.http.ResponseEntity
@@ -11,12 +14,17 @@ import org.springframework.web.bind.annotation.*
 
 @RestController
 @RequestMapping("/api/v1/portfolio")
+@Tag(name = "Portfolio Generation", description = "Generate professional developer portfolios from GitHub profiles")
 class PortfolioController(
     private val portfolioGenerationService: PortfolioGenerationService
 ) {
 
     private val logger = LoggerFactory.getLogger(javaClass)
 
+    @Operation(summary = "Generate developer portfolio", description = "Scans a GitHub user's public repositories and generates a professional portfolio with AI")
+    @ApiResponse(responseCode = "200", description = "Portfolio generated successfully")
+    @ApiResponse(responseCode = "400", description = "Invalid GitHub username")
+    @ApiResponse(responseCode = "404", description = "GitHub user not found")
     @PostMapping("/generate")
     fun generatePortfolio(@Valid @RequestBody request: GeneratePortfolioRequest): ResponseEntity<PortfolioResponse> {
         logger.info("Portfolio generation requested for: {}", request.githubUsername)
@@ -24,12 +32,16 @@ class PortfolioController(
         return ResponseEntity.ok(response)
     }
 
+    @Operation(summary = "Get portfolio by ID")
+    @ApiResponse(responseCode = "200", description = "Portfolio found")
+    @ApiResponse(responseCode = "404", description = "Portfolio not found")
     @GetMapping("/{id}")
     fun getPortfolio(@PathVariable id: Long): ResponseEntity<PortfolioResponse> {
         val response = portfolioGenerationService.getById(id)
         return ResponseEntity.ok(response)
     }
 
+    @Operation(summary = "List all portfolios", description = "Returns summary of all generated portfolios")
     @GetMapping
     fun listPortfolios(): ResponseEntity<List<PortfolioSummaryResponse>> {
         val response = portfolioGenerationService.listAll()


### PR DESCRIPTION
## Summary
- Add springdoc-openapi-starter-webmvc-ui 3.0.1 (compatible with Spring Boot 4)
- OpenAPI config with API metadata, production and local servers
- All 7 endpoints annotated with @Operation and @ApiResponse
- Swagger UI publicly accessible at /swagger-ui.html
- API spec at /api-docs (JSON) and /api-docs.yaml

## Test plan
- [ ] Build and tests pass
- [ ] Swagger UI loads at /swagger-ui.html
- [ ] All endpoints visible in the documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add OpenAPI documentation and public Swagger UI for the Service Portfolio API.

New Features:
- Expose interactive Swagger UI and OpenAPI JSON/YAML specs using springdoc-openapi.
- Document repository analysis and portfolio generation controllers with tags, operation summaries, and response metadata.

Enhancements:
- Configure OpenAPI metadata including API title, description, version, contact, license, and server URLs.
- Update security configuration to allow unauthenticated access to Swagger UI and OpenAPI spec endpoints.

Build:
- Add springdoc-openapi-starter-webmvc-ui 3.0.1 dependency for Spring Boot 4-compatible OpenAPI integration.