### PR TITLE
Add async processing, caching, and rate limiting

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,6 +26,8 @@ Dos flujos principales:
 - **Monitoreo:** Spring Boot Actuator
 - **DB:** PostgreSQL + Spring Data JPA + H2 (tests)
 - **JSON:** Jackson Kotlin Module
+- **Cache:** Spring Cache + Caffeine (in-memory, TTL-based)
+- **Rate Limiting:** Bucket4j (token bucket algorithm)
 - **Tests:** JUnit 5 + Mockito-Kotlin + Spring Security Test
 
 ## Arquitectura
@@ -44,9 +46,14 @@ client/
 └── GitHubAppTokenService → Gestion de tokens de GitHub App (JWT → installation token)
 config/
 ├── AiConfig              → Bean ChatClient de Spring AI
+├── AsyncConfig           → ThreadPoolTaskExecutor para operaciones AI async
+├── CacheConfig           → @EnableCaching + Caffeine cache manager
 ├── GitHubConfig          → Bean GitHub (hub4j) con GitHub App
 ├── GitHubAppProperties   → @ConfigurationProperties para GitHub App
+├── RateLimitConfig       → Reglas de rate limiting por endpoint
 └── SecurityConfig        → Spring Security + OAuth2 + CORS configurable
+filter/
+└── RateLimitFilter       → Servlet filter con Bucket4j (token bucket por IP)
 dtos/                 → Request/Response DTOs (Analyze, Portfolio, ReadmeCommit)
 models/               → RepoAnalysis, RepoContext, DeveloperPortfolio, PortfolioProject, RepoSummary
 entities/             → AnalysisResult, Portfolio (JPA entities)
@@ -140,10 +147,10 @@ Backend API completado con todas las funcionalidades core:
 - CI/CD con GitHub Actions, Docker, y manifiestos Kubernetes
 - Desplegado en: `serviceportfolioapi.pablohgdev.com`
 
-### Mejoras futuras
-- `@EnableAsync` + `@Async` para operaciones AI no-bloqueantes
-- Rate limiting
-- Caché de análisis
+### Implementado recientemente
+- **Async (DeferredResult)**: POST /analyze y POST /portfolio/generate ejecutan en thread pool dedicado (`aiTaskExecutor`), liberando threads de Tomcat
+- **Rate Limiting (Bucket4j)**: Token bucket por IP. POST /analyze: 5/h, POST /generate: 3/h, GET: 60/min. Headers X-RateLimit-* en responses
+- **Cache**: DB deduplication para analisis/portfolios duplicados + Caffeine @Cacheable en GitHub API calls (TTL 30min)
 
 ## Notas para Agentes
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -39,6 +39,9 @@ dependencies {
     implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:3.0.1")
     implementation("org.kohsuke:github-api:2.0-rc.5")
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
+    implementation("org.springframework.boot:spring-boot-starter-cache")
+    implementation("com.github.ben-manes.caffeine:caffeine")
+    implementation("com.bucket4j:bucket4j_jdk17-core:8.16.1")
     // Source: https://mvnrepository.com/artifact/io.jsonwebtoken/jjwt-api
     implementation("io.jsonwebtoken:jjwt-api:0.13.0")
     // Source: https://mvnrepository.com/artifact/io.jsonwebtoken/jjwt-impl

--- a/src/main/kotlin/com/example/serviceportfolio/config/AsyncConfig.kt
+++ b/src/main/kotlin/com/example/serviceportfolio/config/AsyncConfig.kt
@@ -1,0 +1,22 @@
+package com.example.serviceportfolio.config
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor
+import java.util.concurrent.ThreadPoolExecutor
+
+@Configuration
+class AsyncConfig {
+
+    @Bean("aiTaskExecutor")
+    fun aiTaskExecutor(): ThreadPoolTaskExecutor {
+        val executor = ThreadPoolTaskExecutor()
+        executor.corePoolSize = 5
+        executor.maxPoolSize = 15
+        executor.queueCapacity = 50
+        executor.setThreadNamePrefix("ai-task-")
+        executor.setRejectedExecutionHandler(ThreadPoolExecutor.CallerRunsPolicy())
+        executor.initialize()
+        return executor
+    }
+}

--- a/src/main/kotlin/com/example/serviceportfolio/config/CacheConfig.kt
+++ b/src/main/kotlin/com/example/serviceportfolio/config/CacheConfig.kt
@@ -1,0 +1,31 @@
+package com.example.serviceportfolio.config
+
+import com.github.benmanes.caffeine.cache.Caffeine
+import org.springframework.cache.CacheManager
+import org.springframework.cache.annotation.EnableCaching
+import org.springframework.cache.caffeine.CaffeineCacheManager
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import java.time.Duration
+
+@Configuration
+@EnableCaching
+class CacheConfig {
+
+    companion object {
+        const val GITHUB_REPO_CONTEXT_CACHE = "githubRepoContext"
+        const val GITHUB_USER_REPOS_CACHE = "githubUserRepos"
+    }
+
+    @Bean
+    fun cacheManager(): CacheManager {
+        val cacheManager = CaffeineCacheManager(GITHUB_REPO_CONTEXT_CACHE, GITHUB_USER_REPOS_CACHE)
+        cacheManager.setCaffeine(
+            Caffeine.newBuilder()
+                .maximumSize(200)
+                .expireAfterWrite(Duration.ofMinutes(30))
+                .recordStats()
+        )
+        return cacheManager
+    }
+}

--- a/src/main/kotlin/com/example/serviceportfolio/config/RateLimitConfig.kt
+++ b/src/main/kotlin/com/example/serviceportfolio/config/RateLimitConfig.kt
@@ -1,0 +1,30 @@
+package com.example.serviceportfolio.config
+
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class RateLimitConfig {
+
+    data class RateLimitRule(
+        val pathPattern: String,
+        val capacity: Long,
+        val refillTokens: Long,
+        val refillPeriodMinutes: Long
+    )
+
+    companion object {
+        val RATE_LIMIT_RULES = listOf(
+            RateLimitRule("/api/v1/repos/analyze", capacity = 5, refillTokens = 5, refillPeriodMinutes = 60),
+            RateLimitRule("/api/v1/portfolio/generate", capacity = 3, refillTokens = 3, refillPeriodMinutes = 60),
+            RateLimitRule("/api/v1/repos/readme/commit", capacity = 10, refillTokens = 10, refillPeriodMinutes = 60),
+            RateLimitRule("/api/v1/**", capacity = 60, refillTokens = 60, refillPeriodMinutes = 1)
+        )
+
+        val EXEMPT_PATHS = setOf(
+            "/actuator/**",
+            "/swagger-ui/**",
+            "/api-docs/**",
+            "/"
+        )
+    }
+}

--- a/src/main/kotlin/com/example/serviceportfolio/controller/AnalysisController.kt
+++ b/src/main/kotlin/com/example/serviceportfolio/controller/AnalysisController.kt
@@ -15,10 +15,13 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.validation.Valid
 import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.http.ResponseEntity
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClient
 import org.springframework.security.oauth2.client.annotation.RegisteredOAuth2AuthorizedClient
 import org.springframework.web.bind.annotation.*
+import org.springframework.web.context.request.async.DeferredResult
 
 @RestController
 @RequestMapping("/api/v1/repos")
@@ -27,7 +30,8 @@ class AnalysisController(
     private val gitHubRepoService: GitHubRepoService,
     private val aiAnalysisService: AiAnalysisService,
     private val analysisResultRepository: AnalysisResultRepository,
-    private val readmeCommitService: ReadmeCommitService
+    private val readmeCommitService: ReadmeCommitService,
+    @Qualifier("aiTaskExecutor") private val taskExecutor: ThreadPoolTaskExecutor
 ) {
 
     private val logger = LoggerFactory.getLogger(javaClass)
@@ -37,24 +41,48 @@ class AnalysisController(
     @ApiResponse(responseCode = "400", description = "Invalid repository URL")
     @ApiResponse(responseCode = "404", description = "Repository not found")
     @PostMapping("/analyze")
-    fun analyzeRepo(@Valid @RequestBody request: AnalyzeRepoRequest): ResponseEntity<AnalysisResponse> {
+    fun analyzeRepo(@Valid @RequestBody request: AnalyzeRepoRequest): DeferredResult<ResponseEntity<AnalysisResponse>> {
         logger.info("Solicitud de análisis recibida para: {}", request.repoUrl)
 
-        val repoContext = gitHubRepoService.getRepoContext(request.repoUrl)
-        val analysis = aiAnalysisService.analyze(repoContext)
+        val deferredResult = DeferredResult<ResponseEntity<AnalysisResponse>>(120_000L)
+        deferredResult.onTimeout {
+            logger.warn("Timeout al analizar repositorio: {}", request.repoUrl)
+            deferredResult.setErrorResult(
+                RuntimeException("Analysis timed out for ${request.repoUrl}")
+            )
+        }
 
-        val entity = AnalysisResult(
-            repoUrl = request.repoUrl,
-            projectName = analysis.projectName,
-            shortDescription = analysis.shortDescription,
-            techStack = analysis.techStack,
-            detectedFeatures = analysis.detectedFeatures,
-            readmeContent = analysis.readmeMarkdown
-        )
-        val saved = analysisResultRepository.save(entity)
+        taskExecutor.execute {
+            try {
+                val existing = analysisResultRepository.findFirstByRepoUrlOrderByCreatedAtDesc(request.repoUrl)
+                if (existing.isPresent) {
+                    logger.info("Análisis existente encontrado para: {}, id: {}", request.repoUrl, existing.get().id)
+                    deferredResult.setResult(ResponseEntity.ok(existing.get().toResponse()))
+                    return@execute
+                }
 
-        logger.info("Análisis guardado con id: {}", saved.id)
-        return ResponseEntity.ok(saved.toResponse())
+                val repoContext = gitHubRepoService.getRepoContext(request.repoUrl)
+                val analysis = aiAnalysisService.analyze(repoContext)
+
+                val entity = AnalysisResult(
+                    repoUrl = request.repoUrl,
+                    projectName = analysis.projectName,
+                    shortDescription = analysis.shortDescription,
+                    techStack = analysis.techStack,
+                    detectedFeatures = analysis.detectedFeatures,
+                    readmeContent = analysis.readmeMarkdown
+                )
+                val saved = analysisResultRepository.save(entity)
+
+                logger.info("Análisis guardado con id: {}", saved.id)
+                deferredResult.setResult(ResponseEntity.ok(saved.toResponse()))
+            } catch (e: Exception) {
+                logger.error("Error al analizar repositorio {}: {}", request.repoUrl, e.message)
+                deferredResult.setErrorResult(e)
+            }
+        }
+
+        return deferredResult
     }
 
     @Operation(summary = "List all analyses", description = "Returns all repository analyses ordered by creation date")

--- a/src/main/kotlin/com/example/serviceportfolio/controller/PortfolioController.kt
+++ b/src/main/kotlin/com/example/serviceportfolio/controller/PortfolioController.kt
@@ -9,14 +9,18 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.validation.Valid
 import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.http.ResponseEntity
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor
 import org.springframework.web.bind.annotation.*
+import org.springframework.web.context.request.async.DeferredResult
 
 @RestController
 @RequestMapping("/api/v1/portfolio")
 @Tag(name = "Portfolio Generation", description = "Generate professional developer portfolios from GitHub profiles")
 class PortfolioController(
-    private val portfolioGenerationService: PortfolioGenerationService
+    private val portfolioGenerationService: PortfolioGenerationService,
+    @Qualifier("aiTaskExecutor") private val taskExecutor: ThreadPoolTaskExecutor
 ) {
 
     private val logger = LoggerFactory.getLogger(javaClass)
@@ -26,10 +30,28 @@ class PortfolioController(
     @ApiResponse(responseCode = "400", description = "Invalid GitHub username")
     @ApiResponse(responseCode = "404", description = "GitHub user not found")
     @PostMapping("/generate")
-    fun generatePortfolio(@Valid @RequestBody request: GeneratePortfolioRequest): ResponseEntity<PortfolioResponse> {
+    fun generatePortfolio(@Valid @RequestBody request: GeneratePortfolioRequest): DeferredResult<ResponseEntity<PortfolioResponse>> {
         logger.info("Portfolio generation requested for: {}", request.githubUsername)
-        val response = portfolioGenerationService.generate(request.githubUsername)
-        return ResponseEntity.ok(response)
+
+        val deferredResult = DeferredResult<ResponseEntity<PortfolioResponse>>(120_000L)
+        deferredResult.onTimeout {
+            logger.warn("Timeout generating portfolio for: {}", request.githubUsername)
+            deferredResult.setErrorResult(
+                RuntimeException("Portfolio generation timed out for ${request.githubUsername}")
+            )
+        }
+
+        taskExecutor.execute {
+            try {
+                val response = portfolioGenerationService.generate(request.githubUsername)
+                deferredResult.setResult(ResponseEntity.ok(response))
+            } catch (e: Exception) {
+                logger.error("Error generating portfolio for {}: {}", request.githubUsername, e.message)
+                deferredResult.setErrorResult(e)
+            }
+        }
+
+        return deferredResult
     }
 
     @Operation(summary = "Get portfolio by ID")

--- a/src/main/kotlin/com/example/serviceportfolio/exceptions/Exceptions.kt
+++ b/src/main/kotlin/com/example/serviceportfolio/exceptions/Exceptions.kt
@@ -12,3 +12,5 @@ class GitHubApiException(message: String, cause: Throwable? = null) : RuntimeExc
 class AiAnalysisException(message: String, cause: Throwable? = null) : RuntimeException(message , cause)
 
 class ReadmeCommitException(message: String, cause: Throwable? = null) : RuntimeException(message, cause)
+
+class RateLimitExceededException(message: String) : RuntimeException(message)

--- a/src/main/kotlin/com/example/serviceportfolio/exceptions/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/com/example/serviceportfolio/exceptions/GlobalExceptionHandler.kt
@@ -46,6 +46,13 @@ class GlobalExceptionHandler {
         return problem
     }
 
+    @ExceptionHandler(RateLimitExceededException::class)
+    fun handleRateLimit(ex: RateLimitExceededException): ProblemDetail {
+        val problem = ProblemDetail.forStatusAndDetail(HttpStatus.TOO_MANY_REQUESTS, ex.message ?: "Rate limit exceeded")
+        problem.title = "Too Many Requests"
+        return problem
+    }
+
     @ExceptionHandler(MethodArgumentNotValidException::class)
     fun handleValidation(ex: MethodArgumentNotValidException): ProblemDetail {
         val errors = ex.bindingResult.fieldErrors.map { "${it.field}: ${it.defaultMessage}" }

--- a/src/main/kotlin/com/example/serviceportfolio/filter/RateLimitFilter.kt
+++ b/src/main/kotlin/com/example/serviceportfolio/filter/RateLimitFilter.kt
@@ -1,0 +1,96 @@
+package com.example.serviceportfolio.filter
+
+import com.example.serviceportfolio.config.RateLimitConfig
+import com.example.serviceportfolio.exceptions.RateLimitExceededException
+import com.github.benmanes.caffeine.cache.Cache
+import com.github.benmanes.caffeine.cache.Caffeine
+import io.github.bucket4j.Bandwidth
+import io.github.bucket4j.Bucket
+import jakarta.servlet.FilterChain
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.slf4j.LoggerFactory
+import org.springframework.core.annotation.Order
+import org.springframework.stereotype.Component
+import org.springframework.util.AntPathMatcher
+import org.springframework.web.filter.OncePerRequestFilter
+import java.time.Duration
+
+@Component
+@Order(1)
+class RateLimitFilter : OncePerRequestFilter() {
+
+    private val log = LoggerFactory.getLogger(javaClass)
+    private val pathMatcher = AntPathMatcher()
+
+    private val bucketCache: Cache<String, Bucket> = Caffeine.newBuilder()
+        .maximumSize(10_000)
+        .expireAfterAccess(Duration.ofHours(2))
+        .build()
+
+    override fun doFilterInternal(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        filterChain: FilterChain
+    ) {
+        val path = request.requestURI
+
+        if (isExemptPath(path)) {
+            filterChain.doFilter(request, response)
+            return
+        }
+
+        val rule = findApplicableRule(path)
+        if (rule == null) {
+            filterChain.doFilter(request, response)
+            return
+        }
+
+        val clientIp = getClientIp(request)
+        val bucketKey = "$clientIp:${rule.pathPattern}"
+        val bucket = bucketCache.get(bucketKey) { createBucket(rule) }!!
+
+        val probe = bucket.tryConsumeAndReturnRemaining(1)
+
+        if (probe.isConsumed) {
+            response.setHeader("X-RateLimit-Limit", rule.capacity.toString())
+            response.setHeader("X-RateLimit-Remaining", probe.remainingTokens.toString())
+            filterChain.doFilter(request, response)
+        } else {
+            val waitSeconds = probe.nanosToWaitForRefill / 1_000_000_000
+            log.warn("Rate limit exceeded for IP {} on path {}", clientIp, path)
+            response.setHeader("X-RateLimit-Limit", rule.capacity.toString())
+            response.setHeader("X-RateLimit-Remaining", "0")
+            response.setHeader("Retry-After", waitSeconds.toString())
+            throw RateLimitExceededException("Rate limit exceeded. Retry after $waitSeconds seconds")
+        }
+    }
+
+    private fun isExemptPath(path: String): Boolean =
+        RateLimitConfig.EXEMPT_PATHS.any { pathMatcher.match(it, path) }
+
+    private fun findApplicableRule(path: String): RateLimitConfig.RateLimitRule? =
+        RateLimitConfig.RATE_LIMIT_RULES.firstOrNull { pathMatcher.match(it.pathPattern, path) }
+
+    private fun createBucket(rule: RateLimitConfig.RateLimitRule): Bucket {
+        val bandwidth = Bandwidth.builder()
+            .capacity(rule.capacity)
+            .refillIntervally(rule.refillTokens, Duration.ofMinutes(rule.refillPeriodMinutes))
+            .build()
+        return Bucket.builder()
+            .addLimit(bandwidth)
+            .build()
+    }
+
+    private fun getClientIp(request: HttpServletRequest): String {
+        val xForwardedFor = request.getHeader("X-Forwarded-For")
+        if (xForwardedFor != null) {
+            return xForwardedFor.split(",").first().trim()
+        }
+        val xRealIp = request.getHeader("X-Real-IP")
+        if (xRealIp != null) {
+            return xRealIp
+        }
+        return request.remoteAddr
+    }
+}

--- a/src/main/kotlin/com/example/serviceportfolio/repositories/AnalysisResultRepository.kt
+++ b/src/main/kotlin/com/example/serviceportfolio/repositories/AnalysisResultRepository.kt
@@ -2,7 +2,9 @@ package com.example.serviceportfolio.repositories
 
 import com.example.serviceportfolio.entities.AnalysisResult
 import org.springframework.data.jpa.repository.JpaRepository
+import java.util.Optional
 
 interface AnalysisResultRepository : JpaRepository<AnalysisResult, Long> {
     fun findAllByOrderByCreatedAtDesc(): List<AnalysisResult>
+    fun findFirstByRepoUrlOrderByCreatedAtDesc(repoUrl: String): Optional<AnalysisResult>
 }

--- a/src/main/kotlin/com/example/serviceportfolio/repositories/PortfolioRepository.kt
+++ b/src/main/kotlin/com/example/serviceportfolio/repositories/PortfolioRepository.kt
@@ -2,7 +2,9 @@ package com.example.serviceportfolio.repositories
 
 import com.example.serviceportfolio.entities.Portfolio
 import org.springframework.data.jpa.repository.JpaRepository
+import java.util.Optional
 
 interface PortfolioRepository : JpaRepository<Portfolio, Long> {
     fun findAllByOrderByCreatedAtDesc(): List<Portfolio>
+    fun findFirstByGithubUsernameOrderByCreatedAtDesc(githubUsername: String): Optional<Portfolio>
 }

--- a/src/main/kotlin/com/example/serviceportfolio/services/GithubRepoService.kt
+++ b/src/main/kotlin/com/example/serviceportfolio/services/GithubRepoService.kt
@@ -1,6 +1,7 @@
 package com.example.serviceportfolio.services
 
 import com.example.serviceportfolio.client.GitHubAppTokenService
+import com.example.serviceportfolio.config.CacheConfig
 import com.example.serviceportfolio.models.RepoContext
 import com.example.serviceportfolio.models.RepoSummary
 import com.example.serviceportfolio.exceptions.GitHubApiException
@@ -10,6 +11,7 @@ import org.kohsuke.github.GHFileNotFoundException
 import org.kohsuke.github.GitHubBuilder
 import org.kohsuke.github.HttpException
 import org.slf4j.LoggerFactory
+import org.springframework.cache.annotation.Cacheable
 import org.springframework.stereotype.Service
 import java.io.IOException
 
@@ -39,6 +41,7 @@ class GitHubRepoService(
         )
     }
 
+    @Cacheable(value = [CacheConfig.GITHUB_REPO_CONTEXT_CACHE], key = "#repoUrl", unless = "#result == null")
     fun getRepoContext(repoUrl: String): RepoContext {
         val (owner, repo) = GitHubUrlParser.parse(repoUrl)
         logger.info("Fetching repo context for {}/{}", owner, repo)
@@ -120,6 +123,7 @@ class GitHubRepoService(
         return result
     }
 
+    @Cacheable(value = [CacheConfig.GITHUB_USER_REPOS_CACHE], key = "#username", unless = "#result == null || #result.isEmpty()")
     fun listUserRepos(username: String): List<RepoSummary> {
         logger.info("Listing repositories for user: {}", username)
 

--- a/src/main/kotlin/com/example/serviceportfolio/services/PortfolioGenerationService.kt
+++ b/src/main/kotlin/com/example/serviceportfolio/services/PortfolioGenerationService.kt
@@ -23,6 +23,13 @@ class PortfolioGenerationService(
     fun generate(githubUsername: String): PortfolioResponse {
         logger.info("Generating portfolio for: {}", githubUsername)
 
+        val existing = portfolioRepository.findFirstByGithubUsernameOrderByCreatedAtDesc(githubUsername)
+        if (existing.isPresent) {
+            logger.info("Portfolio existente encontrado para: {}, id: {}", githubUsername, existing.get().id)
+            val portfolio = objectMapper.readValue(existing.get().portfolioData, DeveloperPortfolio::class.java)
+            return toResponse(existing.get(), portfolio)
+        }
+
         val repos = gitHubRepoService.listUserRepos(githubUsername)
         if (repos.isEmpty()) {
             throw RepoNotFoundException("No public repositories found for user: $githubUsername")


### PR DESCRIPTION
## Summary
- **DeferredResult async**: POST /analyze and POST /generate execute in dedicated thread pool (`aiTaskExecutor`), freeing Tomcat threads for other requests
- **Caffeine cache**: `@Cacheable` on GitHub API calls (30min TTL) + DB deduplication for duplicate analysis/portfolio requests
- **Bucket4j rate limiting**: Token bucket per IP with `X-RateLimit-*` headers (POST /analyze: 5/h, POST /generate: 3/h, GET: 60/min)

## Changes
- 4 new files: `AsyncConfig`, `CacheConfig`, `RateLimitConfig`, `RateLimitFilter`
- Modified controllers to use `DeferredResult` for async endpoints
- Added `findFirstByRepoUrl` and `findFirstByGithubUsername` repository queries
- Added `@Cacheable` annotations on `GitHubRepoService` methods
- Added `RateLimitExceededException` + 429 handler in `GlobalExceptionHandler`
- Updated controller tests with `asyncDispatch` pattern

## Test plan
- [x] `./gradlew test` - all 29 tests pass
- [x] `./gradlew build` - clean build
- [ ] Verify rate limit headers in deployed API responses
- [ ] Verify duplicate POST /analyze returns cached result instantly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce asynchronous processing, caching, and request rate limiting across core GitHub analysis and portfolio endpoints.

New Features:
- Add async handling for POST /repos/analyze and POST /portfolio/generate using a dedicated thread pool to avoid blocking servlet threads.
- Introduce per-IP rate limiting for API endpoints with configurable rules and X-RateLimit headers, returning 429 on limit exhaustion.
- Enable caching for GitHub repository context and user repositories using Spring Cache with a Caffeine-backed cache manager.

Enhancements:
- Avoid duplicate work by reusing the most recent stored analysis and portfolio records when available instead of recomputing them.
- Extend global exception handling to surface rate limit violations as HTTP 429 responses with structured error details.
- Update controller tests to support asynchronous request processing patterns and import the async configuration.
- Document the new async processing, caching, and rate limiting capabilities in the project guide.

Build:
- Add Spring Cache, Caffeine, and Bucket4j dependencies to the build configuration.