### PR TITLE
feat: SaaS Phase 2 - OAuth2 login with user upsert

### DIFF
--- a/src/main/kotlin/com/example/serviceportfolio/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/example/serviceportfolio/config/SecurityConfig.kt
@@ -1,5 +1,7 @@
 package com.example.serviceportfolio.config
 
+import com.example.serviceportfolio.security.CustomOAuth2UserService
+import com.example.serviceportfolio.security.OAuth2LoginSuccessHandler
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
@@ -19,7 +21,9 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource
 @EnableWebSecurity
 class SecurityConfig(
     @Value("\${app.cors.allowed-origins:http://localhost:3000,http://localhost:5173}")
-    private val allowedOrigins: List<String>
+    private val allowedOrigins: List<String>,
+    private val customOAuth2UserService: CustomOAuth2UserService,
+    private val oAuth2LoginSuccessHandler: OAuth2LoginSuccessHandler
 ) {
 
     @Bean
@@ -45,7 +49,10 @@ class SecurityConfig(
                     .requestMatchers("/").permitAll()
                     .anyRequest().authenticated()
             }
-            .oauth2Login { }
+            .oauth2Login { oauth2 ->
+                oauth2.userInfoEndpoint { it.userService(customOAuth2UserService) }
+                oauth2.successHandler(oAuth2LoginSuccessHandler)
+            }
             .csrf { it.disable() }
         return http.build()
     }

--- a/src/main/kotlin/com/example/serviceportfolio/controller/AuthController.kt
+++ b/src/main/kotlin/com/example/serviceportfolio/controller/AuthController.kt
@@ -1,0 +1,49 @@
+package com.example.serviceportfolio.controller
+
+import com.example.serviceportfolio.dtos.UserResponse
+import com.example.serviceportfolio.security.SecurityUtils
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.servlet.http.HttpServletRequest
+import org.springframework.http.ResponseEntity
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/v1/auth")
+@Tag(name = "Authentication", description = "User authentication and session management")
+class AuthController {
+
+    @Operation(summary = "Get current user", description = "Returns the authenticated user's profile information")
+    @ApiResponse(responseCode = "200", description = "User profile returned")
+    @ApiResponse(responseCode = "401", description = "Not authenticated")
+    @GetMapping("/me")
+    fun getCurrentUser(): ResponseEntity<UserResponse> {
+        val user = SecurityUtils.requireCurrentUser()
+        return ResponseEntity.ok(
+            UserResponse(
+                id = user.id!!,
+                githubUsername = user.githubUsername,
+                name = user.name,
+                email = user.email,
+                avatarUrl = user.avatarUrl,
+                plan = user.plan,
+                analysesUsed = user.analysesUsed,
+                portfoliosUsed = user.portfoliosUsed
+            )
+        )
+    }
+
+    @Operation(summary = "Logout", description = "Invalidates the current session and clears security context")
+    @ApiResponse(responseCode = "200", description = "Logged out successfully")
+    @PostMapping("/logout")
+    fun logout(request: HttpServletRequest): ResponseEntity<Void> {
+        request.session.invalidate()
+        SecurityContextHolder.clearContext()
+        return ResponseEntity.ok().build()
+    }
+}

--- a/src/main/kotlin/com/example/serviceportfolio/dtos/UserResponse.kt
+++ b/src/main/kotlin/com/example/serviceportfolio/dtos/UserResponse.kt
@@ -1,0 +1,14 @@
+package com.example.serviceportfolio.dtos
+
+import java.util.UUID
+
+data class UserResponse(
+    val id: UUID,
+    val githubUsername: String,
+    val name: String?,
+    val email: String?,
+    val avatarUrl: String?,
+    val plan: String,
+    val analysesUsed: Int,
+    val portfoliosUsed: Int
+)

--- a/src/main/kotlin/com/example/serviceportfolio/exceptions/Exceptions.kt
+++ b/src/main/kotlin/com/example/serviceportfolio/exceptions/Exceptions.kt
@@ -14,3 +14,5 @@ class AiAnalysisException(message: String, cause: Throwable? = null) : RuntimeEx
 class ReadmeCommitException(message: String, cause: Throwable? = null) : RuntimeException(message, cause)
 
 class RateLimitExceededException(message: String) : RuntimeException(message)
+
+class AuthenticationRequiredException(message: String) : RuntimeException(message)

--- a/src/main/kotlin/com/example/serviceportfolio/exceptions/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/com/example/serviceportfolio/exceptions/GlobalExceptionHandler.kt
@@ -53,6 +53,13 @@ class GlobalExceptionHandler {
         return problem
     }
 
+    @ExceptionHandler(AuthenticationRequiredException::class)
+    fun handleAuthRequired(ex: AuthenticationRequiredException): ProblemDetail {
+        val problem = ProblemDetail.forStatusAndDetail(HttpStatus.UNAUTHORIZED, ex.message ?: "Authentication required")
+        problem.title = "Authentication Required"
+        return problem
+    }
+
     @ExceptionHandler(MethodArgumentNotValidException::class)
     fun handleValidation(ex: MethodArgumentNotValidException): ProblemDetail {
         val errors = ex.bindingResult.fieldErrors.map { "${it.field}: ${it.defaultMessage}" }

--- a/src/main/kotlin/com/example/serviceportfolio/security/CustomOAuth2User.kt
+++ b/src/main/kotlin/com/example/serviceportfolio/security/CustomOAuth2User.kt
@@ -1,0 +1,9 @@
+package com.example.serviceportfolio.security
+
+import com.example.serviceportfolio.entities.User
+import org.springframework.security.oauth2.core.user.OAuth2User
+
+class CustomOAuth2User(
+    private val delegate: OAuth2User,
+    val user: User
+) : OAuth2User by delegate

--- a/src/main/kotlin/com/example/serviceportfolio/security/CustomOAuth2UserService.kt
+++ b/src/main/kotlin/com/example/serviceportfolio/security/CustomOAuth2UserService.kt
@@ -1,0 +1,48 @@
+package com.example.serviceportfolio.security
+
+import com.example.serviceportfolio.entities.User
+import com.example.serviceportfolio.repositories.UserRepository
+import com.example.serviceportfolio.util.TokenEncryptor
+import org.slf4j.LoggerFactory
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest
+import org.springframework.security.oauth2.core.user.OAuth2User
+import org.springframework.stereotype.Service
+import java.time.Instant
+
+@Service
+class CustomOAuth2UserService(
+    private val userRepository: UserRepository,
+    private val tokenEncryptor: TokenEncryptor
+) : DefaultOAuth2UserService() {
+
+    private val logger = LoggerFactory.getLogger(javaClass)
+
+    override fun loadUser(userRequest: OAuth2UserRequest): OAuth2User {
+        val oAuth2User = super.loadUser(userRequest)
+
+        val githubId = (oAuth2User.attributes["id"] as Number).toLong()
+        val login = oAuth2User.attributes["login"] as String
+        val email = oAuth2User.attributes["email"] as? String
+        val name = oAuth2User.attributes["name"] as? String
+        val avatarUrl = oAuth2User.attributes["avatar_url"] as? String
+        val accessToken = userRequest.accessToken.tokenValue
+
+        val user = userRepository.findByGithubId(githubId).orElseGet {
+            logger.info("Nuevo usuario registrado: {} (githubId: {})", login, githubId)
+            User(githubId = githubId)
+        }
+
+        user.githubUsername = login
+        user.email = email
+        user.name = name
+        user.avatarUrl = avatarUrl
+        user.githubAccessToken = tokenEncryptor.encrypt(accessToken)
+        user.lastLoginAt = Instant.now()
+
+        val savedUser = userRepository.save(user)
+        logger.info("Usuario actualizado: {} (id: {})", login, savedUser.id)
+
+        return CustomOAuth2User(oAuth2User, savedUser)
+    }
+}

--- a/src/main/kotlin/com/example/serviceportfolio/security/OAuth2LoginSuccessHandler.kt
+++ b/src/main/kotlin/com/example/serviceportfolio/security/OAuth2LoginSuccessHandler.kt
@@ -1,0 +1,23 @@
+package com.example.serviceportfolio.security
+
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.security.core.Authentication
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler
+import org.springframework.stereotype.Component
+
+@Component
+class OAuth2LoginSuccessHandler(
+    @Value("\${app.oauth2.success-redirect-url:http://localhost:3000}")
+    private val successRedirectUrl: String
+) : AuthenticationSuccessHandler {
+
+    override fun onAuthenticationSuccess(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        authentication: Authentication
+    ) {
+        response.sendRedirect(successRedirectUrl)
+    }
+}

--- a/src/main/kotlin/com/example/serviceportfolio/security/SecurityUtils.kt
+++ b/src/main/kotlin/com/example/serviceportfolio/security/SecurityUtils.kt
@@ -1,0 +1,19 @@
+package com.example.serviceportfolio.security
+
+import com.example.serviceportfolio.entities.User
+import com.example.serviceportfolio.exceptions.AuthenticationRequiredException
+import org.springframework.security.core.context.SecurityContextHolder
+
+object SecurityUtils {
+
+    fun getCurrentUser(): User? {
+        val authentication = SecurityContextHolder.getContext().authentication ?: return null
+        val principal = authentication.principal
+        return (principal as? CustomOAuth2User)?.user
+    }
+
+    fun requireCurrentUser(): User {
+        return getCurrentUser()
+            ?: throw AuthenticationRequiredException("User not authenticated")
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -45,6 +45,8 @@ app:
   encryption:
     password: ${APP_ENCRYPTION_PASSWORD}
     salt: ${APP_ENCRYPTION_SALT}
+  oauth2:
+    success-redirect-url: ${APP_OAUTH2_SUCCESS_REDIRECT_URL:http://localhost:3000}
 
 github:
   app:

--- a/src/test/kotlin/com/example/serviceportfolio/controller/AuthControllerTest.kt
+++ b/src/test/kotlin/com/example/serviceportfolio/controller/AuthControllerTest.kt
@@ -1,0 +1,113 @@
+package com.example.serviceportfolio.controller
+
+import com.example.serviceportfolio.entities.User
+import com.example.serviceportfolio.security.CustomOAuth2User
+import com.example.serviceportfolio.security.CustomOAuth2UserService
+import com.example.serviceportfolio.security.OAuth2LoginSuccessHandler
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User
+import org.springframework.security.oauth2.core.user.OAuth2UserAuthority
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.oauth2Login
+import org.springframework.test.context.bean.override.mockito.MockitoBean
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import java.util.UUID
+
+@WebMvcTest(AuthController::class)
+class AuthControllerTest {
+
+    @Autowired
+    private lateinit var mockMvc: MockMvc
+
+    @MockitoBean
+    private lateinit var customOAuth2UserService: CustomOAuth2UserService
+
+    @MockitoBean
+    private lateinit var oAuth2LoginSuccessHandler: OAuth2LoginSuccessHandler
+
+    private fun createTestUser(): User {
+        return User(
+            githubId = 12345L,
+            githubUsername = "testuser",
+            email = "test@example.com",
+            name = "Test User",
+            avatarUrl = "https://avatars.githubusercontent.com/u/12345"
+        ).apply { id = UUID.fromString("00000000-0000-0000-0000-000000000001") }
+    }
+
+    private fun createCustomOAuth2User(user: User): CustomOAuth2User {
+        val attributes = mapOf<String, Any>(
+            "id" to user.githubId,
+            "login" to user.githubUsername,
+            "name" to (user.name ?: ""),
+            "email" to (user.email ?: ""),
+            "avatar_url" to (user.avatarUrl ?: "")
+        )
+        val authority = OAuth2UserAuthority(attributes)
+        val defaultOAuth2User = DefaultOAuth2User(listOf(authority), attributes, "login")
+        return CustomOAuth2User(defaultOAuth2User, user)
+    }
+
+    @Test
+    fun `get me returns 200 with user data`() {
+        val user = createTestUser()
+        val customUser = createCustomOAuth2User(user)
+
+        mockMvc.perform(
+            get("/api/v1/auth/me")
+                .with(oauth2Login().oauth2User(customUser))
+        )
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.id").value("00000000-0000-0000-0000-000000000001"))
+            .andExpect(jsonPath("$.githubUsername").value("testuser"))
+            .andExpect(jsonPath("$.name").value("Test User"))
+            .andExpect(jsonPath("$.email").value("test@example.com"))
+            .andExpect(jsonPath("$.avatarUrl").value("https://avatars.githubusercontent.com/u/12345"))
+            .andExpect(jsonPath("$.plan").value("FREE"))
+            .andExpect(jsonPath("$.analysesUsed").value(0))
+            .andExpect(jsonPath("$.portfoliosUsed").value(0))
+    }
+
+    @Test
+    fun `get me without auth redirects to login`() {
+        mockMvc.perform(get("/api/v1/auth/me"))
+            .andExpect(status().is3xxRedirection)
+    }
+
+    @Test
+    fun `get me with default oauth2Login returns 401 when no custom principal`() {
+        mockMvc.perform(
+            get("/api/v1/auth/me")
+                .with(oauth2Login())
+        )
+            .andExpect(status().isUnauthorized)
+    }
+
+    @Test
+    fun `logout returns 200`() {
+        val user = createTestUser()
+        val customUser = createCustomOAuth2User(user)
+
+        mockMvc.perform(
+            post("/api/v1/auth/logout")
+                .with(oauth2Login().oauth2User(customUser))
+                .with(csrf())
+        )
+            .andExpect(status().isOk)
+    }
+
+    @Test
+    fun `logout without auth redirects to login`() {
+        mockMvc.perform(
+            post("/api/v1/auth/logout")
+                .with(csrf())
+        )
+            .andExpect(status().is3xxRedirection)
+    }
+}

--- a/src/test/resources/application.yaml
+++ b/src/test/resources/application.yaml
@@ -25,6 +25,8 @@ app:
   encryption:
     password: test-encryption-password
     salt: abcdef0123456789
+  oauth2:
+    success-redirect-url: http://localhost:3000
 
 github:
   app:


### PR DESCRIPTION
## Summary
- **CustomOAuth2UserService**: On GitHub OAuth2 login, upserts user profile into `users` table and encrypts the access token via `TokenEncryptor`
- **CustomOAuth2User**: Kotlin delegation wrapper (`OAuth2User by delegate`) that carries the `User` JPA entity in the security principal
- **AuthController**: `GET /api/v1/auth/me` (returns authenticated user profile) + `POST /api/v1/auth/logout` (invalidates session)
- **OAuth2LoginSuccessHandler**: Redirects to configurable frontend URL after successful login (`app.oauth2.success-redirect-url`)
- **SecurityUtils**: Object utility to extract current `User` from `SecurityContextHolder`
- **AuthenticationRequiredException** + GlobalExceptionHandler for 401 responses

## Files changed (12)
- 7 new files (4 security/, 1 controller, 1 DTO, 1 test)
- 5 modified (SecurityConfig, Exceptions, GlobalExceptionHandler, application.yaml x2)

## Backwards compatibility
- `JdbcOAuth2AuthorizedClientService` maintained (commitReadme depends on it until Phase 7)
- Existing endpoints unchanged - no auth behavior changes for public endpoints
- All 34 tests pass (29 existing + 5 new)

## Test plan
- [x] `./gradlew test` - All tests pass
- [x] `GET /api/v1/auth/me` with CustomOAuth2User principal returns 200 + user data
- [x] `GET /api/v1/auth/me` without auth returns redirect (302)
- [x] `GET /api/v1/auth/me` with default OAuth2User returns 401
- [x] `POST /api/v1/auth/logout` with auth returns 200
- [x] `POST /api/v1/auth/logout` without auth returns redirect (302)
- [ ] Manual: GitHub OAuth login flow creates/updates user in DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add OAuth2-based authentication flow with user upsert, session management endpoints, and supporting security utilities for GitHub login.

New Features:
- Introduce CustomOAuth2UserService to upsert GitHub-authenticated users into the database and store encrypted access tokens.
- Add CustomOAuth2User principal wrapper and SecurityUtils helper to expose the current User from the security context.
- Expose /api/v1/auth/me endpoint to return the authenticated user profile and /api/v1/auth/logout to invalidate the current session.
- Configure OAuth2 login to use a custom success handler that redirects to a configurable frontend URL after successful authentication.

Enhancements:
- Extend security configuration to plug in the custom OAuth2 user service and login success handler.
- Return standardized 401 ProblemDetail responses via AuthenticationRequiredException handling in GlobalExceptionHandler.

Tests:
- Add AuthController WebMvc tests covering authenticated profile retrieval, unauthenticated access behavior, and logout flows.

Chores:
- Add application configuration property for OAuth2 success redirect URL in main and test YAML configs.