### PR TITLE
feat: SaaS Phase 3 - Resource ownership and user-scoped endpoints

### DIFF
--- a/src/main/kotlin/com/example/serviceportfolio/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/example/serviceportfolio/config/SecurityConfig.kt
@@ -43,6 +43,8 @@ class SecurityConfig(
                     .requestMatchers("/api/v1/repos/analyze").permitAll()
                     .requestMatchers("/api/v1/repos/analyses").permitAll()
                     .requestMatchers("/api/v1/repos/analyses/{id}").permitAll()
+                    .requestMatchers("/api/v1/repos/my-analyses").authenticated()
+                    .requestMatchers("/api/v1/portfolio/my-portfolios").authenticated()
                     .requestMatchers("/api/v1/portfolio/**").permitAll()
                     .requestMatchers("/actuator/health").permitAll()
                     .requestMatchers("/swagger-ui/**", "/swagger-ui.html", "/v3/api-docs/**", "/v3/api-docs.yaml").permitAll()

--- a/src/main/kotlin/com/example/serviceportfolio/repositories/AnalysisResultRepository.kt
+++ b/src/main/kotlin/com/example/serviceportfolio/repositories/AnalysisResultRepository.kt
@@ -1,10 +1,12 @@
 package com.example.serviceportfolio.repositories
 
 import com.example.serviceportfolio.entities.AnalysisResult
+import com.example.serviceportfolio.entities.User
 import org.springframework.data.jpa.repository.JpaRepository
 import java.util.Optional
 
 interface AnalysisResultRepository : JpaRepository<AnalysisResult, Long> {
     fun findAllByOrderByCreatedAtDesc(): List<AnalysisResult>
     fun findFirstByRepoUrlOrderByCreatedAtDesc(repoUrl: String): Optional<AnalysisResult>
+    fun findAllByUserOrderByCreatedAtDesc(user: User): List<AnalysisResult>
 }

--- a/src/main/kotlin/com/example/serviceportfolio/repositories/PortfolioRepository.kt
+++ b/src/main/kotlin/com/example/serviceportfolio/repositories/PortfolioRepository.kt
@@ -1,10 +1,12 @@
 package com.example.serviceportfolio.repositories
 
 import com.example.serviceportfolio.entities.Portfolio
+import com.example.serviceportfolio.entities.User
 import org.springframework.data.jpa.repository.JpaRepository
 import java.util.Optional
 
 interface PortfolioRepository : JpaRepository<Portfolio, Long> {
     fun findAllByOrderByCreatedAtDesc(): List<Portfolio>
     fun findFirstByGithubUsernameOrderByCreatedAtDesc(githubUsername: String): Optional<Portfolio>
+    fun findAllByUserOrderByCreatedAtDesc(user: User): List<Portfolio>
 }


### PR DESCRIPTION
## Summary
- **Ownership on creation**: Analyses and portfolios are linked to the authenticated user (`user_id`) when created. Anonymous users still work (user_id = NULL).
- **Async-safe**: `SecurityUtils.getCurrentUser()` captured BEFORE `taskExecutor.execute {}` to avoid ThreadLocal propagation issues.
- **New endpoints**: `GET /api/v1/repos/my-analyses` and `GET /api/v1/portfolio/my-portfolios` return only resources owned by the authenticated user.
- **SecurityConfig**: `/my-portfolios` explicitly authenticated before the `portfolio/**` permitAll wildcard.
- **PortfolioGenerationService**: `generate()` accepts optional `User?` parameter with default null.

## Files changed (8)
- 6 modified (SecurityConfig, AnalysisController, PortfolioController, PortfolioGenerationService, both repositories)
- 2 test files updated (4 new tests + Mockito matcher fixes)

## Backwards compatibility
- Existing endpoints unchanged (public, show all resources)
- `user_id` is nullable - existing data with NULL continues working
- Global dedup maintained (first analysis of a repo cached for everyone)
- All 38 tests pass (34 existing + 4 new)

## Test plan
- [x] `./gradlew test` - All 38 tests pass
- [x] `GET /my-analyses` with CustomOAuth2User returns user's analyses
- [x] `GET /my-analyses` without auth redirects to login
- [x] `GET /my-portfolios` with CustomOAuth2User returns user's portfolios
- [x] `GET /my-portfolios` without auth redirects to login
- [ ] Manual: POST /analyze while authenticated sets user_id on entity

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add user-scoped ownership and listing for analyses and portfolios while keeping existing public endpoints unchanged.

New Features:
- Associate newly created analyses and portfolios with the currently authenticated user when available.
- Expose GET /api/v1/repos/my-analyses to return analyses owned by the authenticated user.
- Expose GET /api/v1/portfolio/my-portfolios to return portfolios owned by the authenticated user.

Enhancements:
- Extend portfolio generation service to optionally accept a user for ownership assignment and provide a user-scoped listing method.
- Update security configuration to require authentication for user-scoped analysis and portfolio endpoints while leaving other endpoints public.

Tests:
- Add controller tests for authenticated and unauthenticated access to the new user-scoped analysis and portfolio endpoints.