### PR TITLE
feat: SaaS Phase 5 - Monthly usage limits per plan

### DIFF
--- a/src/main/kotlin/com/example/serviceportfolio/controller/AuthController.kt
+++ b/src/main/kotlin/com/example/serviceportfolio/controller/AuthController.kt
@@ -33,7 +33,8 @@ class AuthController {
                 avatarUrl = user.avatarUrl,
                 plan = user.plan,
                 analysesUsed = user.analysesUsed,
-                portfoliosUsed = user.portfoliosUsed
+                portfoliosUsed = user.portfoliosUsed,
+                usageResetAt = user.usageResetAt
             )
         )
     }

--- a/src/main/kotlin/com/example/serviceportfolio/dtos/UserResponse.kt
+++ b/src/main/kotlin/com/example/serviceportfolio/dtos/UserResponse.kt
@@ -1,5 +1,6 @@
 package com.example.serviceportfolio.dtos
 
+import java.time.Instant
 import java.util.UUID
 
 data class UserResponse(
@@ -10,5 +11,6 @@ data class UserResponse(
     val avatarUrl: String?,
     val plan: String,
     val analysesUsed: Int,
-    val portfoliosUsed: Int
+    val portfoliosUsed: Int,
+    val usageResetAt: Instant
 )

--- a/src/main/kotlin/com/example/serviceportfolio/exceptions/Exceptions.kt
+++ b/src/main/kotlin/com/example/serviceportfolio/exceptions/Exceptions.kt
@@ -16,3 +16,5 @@ class ReadmeCommitException(message: String, cause: Throwable? = null) : Runtime
 class RateLimitExceededException(message: String) : RuntimeException(message)
 
 class AuthenticationRequiredException(message: String) : RuntimeException(message)
+
+class UsageLimitExceededException(message: String) : RuntimeException(message)

--- a/src/main/kotlin/com/example/serviceportfolio/exceptions/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/com/example/serviceportfolio/exceptions/GlobalExceptionHandler.kt
@@ -60,6 +60,13 @@ class GlobalExceptionHandler {
         return problem
     }
 
+    @ExceptionHandler(UsageLimitExceededException::class)
+    fun handleUsageLimit(ex: UsageLimitExceededException): ProblemDetail {
+        val problem = ProblemDetail.forStatusAndDetail(HttpStatus.FORBIDDEN, ex.message ?: "Usage limit exceeded")
+        problem.title = "Usage Limit Exceeded"
+        return problem
+    }
+
     @ExceptionHandler(MethodArgumentNotValidException::class)
     fun handleValidation(ex: MethodArgumentNotValidException): ProblemDetail {
         val errors = ex.bindingResult.fieldErrors.map { "${it.field}: ${it.defaultMessage}" }

--- a/src/main/kotlin/com/example/serviceportfolio/services/UsageLimitService.kt
+++ b/src/main/kotlin/com/example/serviceportfolio/services/UsageLimitService.kt
@@ -1,0 +1,76 @@
+package com.example.serviceportfolio.services
+
+import com.example.serviceportfolio.entities.User
+import com.example.serviceportfolio.exceptions.UsageLimitExceededException
+import com.example.serviceportfolio.repositories.UserRepository
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+import java.time.Instant
+import java.time.YearMonth
+import java.time.ZoneOffset
+
+@Service
+class UsageLimitService(
+    private val userRepository: UserRepository
+) {
+
+    private val logger = LoggerFactory.getLogger(javaClass)
+
+    companion object {
+        val PLAN_LIMITS = mapOf(
+            "FREE" to PlanLimits(analyses = 5, portfolios = 3),
+            "PRO" to PlanLimits(analyses = 50, portfolios = 20)
+        )
+    }
+
+    data class PlanLimits(val analyses: Int, val portfolios: Int)
+
+    fun checkAnalysisLimit(user: User) {
+        resetIfNeeded(user)
+        val limits = PLAN_LIMITS[user.plan] ?: PLAN_LIMITS["FREE"]!!
+        if (user.analysesUsed >= limits.analyses) {
+            throw UsageLimitExceededException(
+                "Monthly analysis limit reached (${user.analysesUsed}/${limits.analyses}). " +
+                "Resets at ${user.usageResetAt}."
+            )
+        }
+    }
+
+    fun checkPortfolioLimit(user: User) {
+        resetIfNeeded(user)
+        val limits = PLAN_LIMITS[user.plan] ?: PLAN_LIMITS["FREE"]!!
+        if (user.portfoliosUsed >= limits.portfolios) {
+            throw UsageLimitExceededException(
+                "Monthly portfolio limit reached (${user.portfoliosUsed}/${limits.portfolios}). " +
+                "Resets at ${user.usageResetAt}."
+            )
+        }
+    }
+
+    fun incrementAnalysisUsage(user: User) {
+        user.analysesUsed++
+        userRepository.save(user)
+        logger.debug("Analysis usage incremented for user {}: {}", user.githubUsername, user.analysesUsed)
+    }
+
+    fun incrementPortfolioUsage(user: User) {
+        user.portfoliosUsed++
+        userRepository.save(user)
+        logger.debug("Portfolio usage incremented for user {}: {}", user.githubUsername, user.portfoliosUsed)
+    }
+
+    private fun resetIfNeeded(user: User) {
+        if (Instant.now().isAfter(user.usageResetAt)) {
+            logger.info("Resetting usage counters for user {}", user.githubUsername)
+            user.analysesUsed = 0
+            user.portfoliosUsed = 0
+            user.usageResetAt = calculateNextResetDate()
+            userRepository.save(user)
+        }
+    }
+
+    private fun calculateNextResetDate(): Instant {
+        val nextMonth = YearMonth.now(ZoneOffset.UTC).plusMonths(1)
+        return nextMonth.atDay(1).atStartOfDay().toInstant(ZoneOffset.UTC)
+    }
+}

--- a/src/test/kotlin/com/example/serviceportfolio/controller/AuthControllerTest.kt
+++ b/src/test/kotlin/com/example/serviceportfolio/controller/AuthControllerTest.kt
@@ -72,6 +72,7 @@ class AuthControllerTest {
             .andExpect(jsonPath("$.plan").value("FREE"))
             .andExpect(jsonPath("$.analysesUsed").value(0))
             .andExpect(jsonPath("$.portfoliosUsed").value(0))
+            .andExpect(jsonPath("$.usageResetAt").exists())
     }
 
     @Test

--- a/src/test/kotlin/com/example/serviceportfolio/services/UsageLimitServiceTest.kt
+++ b/src/test/kotlin/com/example/serviceportfolio/services/UsageLimitServiceTest.kt
@@ -1,0 +1,147 @@
+package com.example.serviceportfolio.services
+
+import com.example.serviceportfolio.entities.User
+import com.example.serviceportfolio.exceptions.UsageLimitExceededException
+import com.example.serviceportfolio.repositories.UserRepository
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
+import org.mockito.kotlin.any
+import java.time.Instant
+import java.time.YearMonth
+import java.time.ZoneOffset
+
+class UsageLimitServiceTest {
+
+    private lateinit var userRepository: UserRepository
+    private lateinit var usageLimitService: UsageLimitService
+
+    @BeforeEach
+    fun setUp() {
+        userRepository = mock()
+        usageLimitService = UsageLimitService(userRepository)
+    }
+
+    private fun createUser(
+        plan: String = "FREE",
+        analysesUsed: Int = 0,
+        portfoliosUsed: Int = 0,
+        usageResetAt: Instant = Instant.now().plusSeconds(86400)
+    ): User {
+        return User(
+            githubId = 12345L,
+            githubUsername = "testuser"
+        ).apply {
+            this.plan = plan
+            this.analysesUsed = analysesUsed
+            this.portfoliosUsed = portfoliosUsed
+            this.usageResetAt = usageResetAt
+        }
+    }
+
+    // --- checkAnalysisLimit ---
+
+    @Test
+    fun `checkAnalysisLimit does not throw when under limit`() {
+        val user = createUser(analysesUsed = 3)
+        usageLimitService.checkAnalysisLimit(user)
+    }
+
+    @Test
+    fun `checkAnalysisLimit throws when at limit`() {
+        val user = createUser(analysesUsed = 5)
+        assertThrows(UsageLimitExceededException::class.java) {
+            usageLimitService.checkAnalysisLimit(user)
+        }
+    }
+
+    @Test
+    fun `checkAnalysisLimit uses PRO limits for PRO plan`() {
+        val user = createUser(plan = "PRO", analysesUsed = 10)
+        usageLimitService.checkAnalysisLimit(user)
+    }
+
+    @Test
+    fun `checkAnalysisLimit throws for PRO plan at limit`() {
+        val user = createUser(plan = "PRO", analysesUsed = 50)
+        assertThrows(UsageLimitExceededException::class.java) {
+            usageLimitService.checkAnalysisLimit(user)
+        }
+    }
+
+    // --- checkPortfolioLimit ---
+
+    @Test
+    fun `checkPortfolioLimit does not throw when under limit`() {
+        val user = createUser(portfoliosUsed = 1)
+        usageLimitService.checkPortfolioLimit(user)
+    }
+
+    @Test
+    fun `checkPortfolioLimit throws when at limit`() {
+        val user = createUser(portfoliosUsed = 3)
+        assertThrows(UsageLimitExceededException::class.java) {
+            usageLimitService.checkPortfolioLimit(user)
+        }
+    }
+
+    // --- incrementAnalysisUsage ---
+
+    @Test
+    fun `incrementAnalysisUsage increments counter and saves`() {
+        val user = createUser(analysesUsed = 2)
+        `when`(userRepository.save(any<User>())).thenReturn(user)
+
+        usageLimitService.incrementAnalysisUsage(user)
+
+        assertEquals(3, user.analysesUsed)
+        verify(userRepository).save(user)
+    }
+
+    // --- incrementPortfolioUsage ---
+
+    @Test
+    fun `incrementPortfolioUsage increments counter and saves`() {
+        val user = createUser(portfoliosUsed = 1)
+        `when`(userRepository.save(any<User>())).thenReturn(user)
+
+        usageLimitService.incrementPortfolioUsage(user)
+
+        assertEquals(2, user.portfoliosUsed)
+        verify(userRepository).save(user)
+    }
+
+    // --- resetIfNeeded ---
+
+    @Test
+    fun `checkAnalysisLimit resets counters when reset date has passed`() {
+        val user = createUser(
+            analysesUsed = 5,
+            portfoliosUsed = 3,
+            usageResetAt = Instant.now().minusSeconds(86400)
+        )
+        `when`(userRepository.save(any<User>())).thenReturn(user)
+
+        usageLimitService.checkAnalysisLimit(user)
+
+        assertEquals(0, user.analysesUsed)
+        assertEquals(0, user.portfoliosUsed)
+
+        val expectedResetDate = YearMonth.now(ZoneOffset.UTC).plusMonths(1)
+            .atDay(1).atStartOfDay().toInstant(ZoneOffset.UTC)
+        assertEquals(expectedResetDate, user.usageResetAt)
+        verify(userRepository).save(user)
+    }
+
+    @Test
+    fun `checkAnalysisLimit falls back to FREE limits for unknown plan`() {
+        val user = createUser(plan = "UNKNOWN", analysesUsed = 5)
+        assertThrows(UsageLimitExceededException::class.java) {
+            usageLimitService.checkAnalysisLimit(user)
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add `UsageLimitService` with plan-based monthly limits (FREE: 5 analyses/3 portfolios, PRO: 50/20)
- Check limits before async AI calls (fail fast → 403 Forbidden) and increment after successful creation
- Automatic monthly reset when `usageResetAt` passes, expose in GET /me response
- Exclude `RateLimitFilter` from controller tests to prevent bucket exhaustion across test methods

## Test plan
- [x] 52 tests passing (10 new: UsageLimitServiceTest + 403 controller tests)
- [ ] Verify POST /analyze returns 403 when analysis limit reached
- [ ] Verify POST /portfolio/generate returns 403 when portfolio limit reached
- [ ] Verify GET /me includes `usageResetAt` field
- [ ] Verify counters reset when `usageResetAt` has passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce plan-based monthly usage limits for analyses and portfolio generation, enforce them in relevant controllers, and expose reset information in the authenticated user response.

New Features:
- Add UsageLimitService with per-plan monthly quotas for analyses and generated portfolios, including automatic monthly reset handling.
- Expose the next usage reset timestamp on the GET /me user response.

Enhancements:
- Enforce usage limits in analysis and portfolio generation endpoints, returning 403 when limits are exceeded.
- Add centralized handling of usage limit violations via a dedicated UsageLimitExceededException mapped to HTTP 403 Forbidden responses.

Tests:
- Add unit tests for UsageLimitService covering limits per plan, reset behavior, and counter increments.
- Extend controller tests to verify 403 responses when usage limits are exceeded and update AuthController tests for the new usageResetAt field.