### PR TITLE
feat: SaaS Phase 6 - Token-based commit from stored user token

### DIFF
--- a/src/main/kotlin/com/example/serviceportfolio/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/example/serviceportfolio/config/SecurityConfig.kt
@@ -5,12 +5,8 @@ import com.example.serviceportfolio.security.OAuth2LoginSuccessHandler
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
-import org.springframework.jdbc.core.JdbcTemplate
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
-import org.springframework.security.oauth2.client.JdbcOAuth2AuthorizedClientService
-import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService
-import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository
 import org.springframework.security.web.SecurityFilterChain
 import org.springframework.web.cors.CorsConfiguration
 import org.springframework.web.cors.CorsConfigurationSource
@@ -25,14 +21,6 @@ class SecurityConfig(
     private val customOAuth2UserService: CustomOAuth2UserService,
     private val oAuth2LoginSuccessHandler: OAuth2LoginSuccessHandler
 ) {
-
-    @Bean
-    fun authorizedClientService(
-        jdbcTemplate: JdbcTemplate,
-        clientRegistrationRepository: ClientRegistrationRepository
-    ): OAuth2AuthorizedClientService {
-        return JdbcOAuth2AuthorizedClientService(jdbcTemplate, clientRegistrationRepository)
-    }
 
     @Bean
     fun securityFilterChain(http: HttpSecurity): SecurityFilterChain {


### PR DESCRIPTION
## Summary
- Replace `@RegisteredOAuth2AuthorizedClient` with stored encrypted token from `User.githubAccessToken`
- Remove `JdbcOAuth2AuthorizedClientService` bean from SecurityConfig (no longer needed)
- Commit endpoint now uses `SecurityUtils.requireCurrentUser()` + `TokenEncryptor.decrypt()`

## Test plan
- [x] 53 tests passing (1 new: 401 when token not available)
- [ ] Verify POST /readme/commit works with stored encrypted token
- [ ] Verify POST /readme/commit returns 401 when user has no GitHub token
- [ ] Verify SecurityConfig no longer exposes `authorizedClientService` bean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Use stored, encrypted GitHub access tokens on the user entity for README commit operations instead of Spring’s OAuth2 authorized client service.

Bug Fixes:
- Return 401 Unauthorized from the README commit endpoint when no GitHub token is available for the current user.

Enhancements:
- Remove the JDBC-backed OAuth2AuthorizedClientService bean from the security configuration as it is no longer needed.
- Inject and use a TokenEncryptor to decrypt the persisted GitHub token before performing README commits.
- Adapt controller logic and tests to rely on the authenticated custom user and decrypted token rather than the registered OAuth2 authorized client.

Tests:
- Add and update controller tests to cover successful README commit with a stored token and 401 responses when the token is missing.