### PR TITLE
feat: SaaS Phase 7 - Drop unused oauth2_authorized_client table

### DIFF
--- a/src/main/resources/db/migration/V3__drop_oauth2_authorized_client.sql
+++ b/src/main/resources/db/migration/V3__drop_oauth2_authorized_client.sql
@@ -1,0 +1,2 @@
+-- V3: Drop oauth2_authorized_client table (tokens now stored encrypted in users table)
+DROP TABLE IF EXISTS oauth2_authorized_client;


### PR DESCRIPTION
## Summary
- Adds Flyway V3 migration to `DROP TABLE IF EXISTS oauth2_authorized_client`
- Table was created in V1 for `JdbcOAuth2AuthorizedClientService` (unencrypted token storage)
- Since Phase 2, tokens are stored encrypted in `users.github_access_token`
- Phase 6 removed the JDBC service bean, leaving the table with orphaned sensitive data
- Eliminates tech debt and removes unencrypted token residue from production DB

## Test plan
- [x] All 53 tests pass (`./gradlew test`)
- [x] V3 migration uses `DROP TABLE IF EXISTS` for idempotency
- [x] `schema.sql` (H2 tests) kept intact — Spring Boot auto-config still needs it for test context

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Enhancements:
- Introduce a V3 Flyway migration that drops the obsolete oauth2_authorized_client table if it exists to clean up legacy unencrypted token storage.