### PR TITLE
fix: filter empty repos and enhance portfolio AI prompt

### DIFF
--- a/src/main/kotlin/com/example/serviceportfolio/models/RepoSummary.kt
+++ b/src/main/kotlin/com/example/serviceportfolio/models/RepoSummary.kt
@@ -4,7 +4,9 @@ data class RepoSummary(
     val name: String,
     val description: String?,
     val primaryLanguage: String?,
+    val languages: Map<String, Long>,
     val stars: Int,
     val forks: Int,
+    val sizeKb: Int,
     val url: String
 )

--- a/src/main/kotlin/com/example/serviceportfolio/services/AiAnalysisService.kt
+++ b/src/main/kotlin/com/example/serviceportfolio/services/AiAnalysisService.kt
@@ -163,6 +163,8 @@ class AiAnalysisService(
         appendLine("   - El tono debe ser profesional, tecnico y atractivo para un recruiter")
         appendLine()
         appendLine("3. **selectedProjects**: Selecciona los 6-10 repositorios mas representativos e interesantes.")
+        appendLine("   - NUNCA selecciones repos con tamano menor a 10 KB, ya que probablemente solo contienen boilerplate o estan practicamente vacios")
+        appendLine("   - Prioriza repos con mayor tamano, mas lenguajes, y descripciones claras")
         appendLine("   - Prioriza DIVERSIDAD tecnologica (no elegir 5 proyectos del mismo stack)")
         appendLine("   - Para cada proyecto:")
         appendLine("     - **repoName**: Nombre exacto del repositorio (tal como aparece abajo)")
@@ -189,7 +191,15 @@ class AiAnalysisService(
         repos.forEachIndexed { index, repo ->
             appendLine("### ${index + 1}. ${repo.name}")
             appendLine("- URL: ${repo.url}")
+            appendLine("- Tamano: ${repo.sizeKb} KB")
             appendLine("- Lenguaje principal: ${repo.primaryLanguage ?: "No especificado"}")
+            if (repo.languages.isNotEmpty()) {
+                val total = repo.languages.values.sum().toDouble()
+                val langBreakdown = repo.languages.entries
+                    .sortedByDescending { it.value }
+                    .joinToString(", ") { (lang, bytes) -> "$lang ${(bytes / total * 100).toInt()}%" }
+                appendLine("- Lenguajes: $langBreakdown")
+            }
             appendLine("- Stars: ${repo.stars} | Forks: ${repo.forks}")
             if (repo.description != null) {
                 appendLine("- Descripcion: ${repo.description}")

--- a/src/main/kotlin/com/example/serviceportfolio/services/GithubRepoService.kt
+++ b/src/main/kotlin/com/example/serviceportfolio/services/GithubRepoService.kt
@@ -136,7 +136,7 @@ class GitHubRepoService(
 
             return user.getRepositories()
                 .values
-                .filter { !it.isArchived && !it.isFork }
+                .filter { !it.isArchived && !it.isFork && it.size > 0 }
                 .sortedByDescending { it.pushedAt }
                 .take(MAX_REPOS_FOR_PORTFOLIO)
                 .map { repo ->
@@ -144,8 +144,10 @@ class GitHubRepoService(
                         name = repo.name,
                         description = repo.description,
                         primaryLanguage = repo.language,
+                        languages = repo.listLanguages(),
                         stars = repo.stargazersCount,
                         forks = repo.forksCount,
+                        sizeKb = repo.size,
                         url = repo.htmlUrl.toString()
                     )
                 }


### PR DESCRIPTION
## Summary
- Add `languages` map and `sizeKb` to `RepoSummary` for richer AI context
- Filter repos with `size=0` in `GithubRepoService.listUserRepos()`
- Include size and language breakdown per repo in portfolio AI prompt
- Instruct AI to skip repos < 10KB (likely boilerplate only)

## Test plan
- [x] All 53 tests pass
- [ ] Test portfolio generation - verify empty/trivial repos filtered out

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Enhance portfolio AI analysis by enriching repository metadata and filtering out trivial repositories from GitHub results.

New Features:
- Expose per-repository language breakdown and size in the RepoSummary model for AI consumption.

Bug Fixes:
- Exclude zero-size GitHub repositories from portfolio generation to avoid empty or boilerplate projects.

Enhancements:
- Augment the AI portfolio prompt with guidance to avoid very small repositories and prioritize larger, well-described, and diverse projects.
- Include repository size and derived language percentage breakdown in the AI portfolio prompt context.